### PR TITLE
Add functionality to change modal's position

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -3,6 +3,7 @@ import FwbModalExample from './modal/examples/FwbModalExample.vue'
 import FwbModalExampleSize from './modal/examples/FwbModalExampleSize.vue'
 import FwbModalExampleEscapable from './modal/examples/FwbModalExampleEscapable.vue'
 import FwbModalExamplePersistent from './modal/examples/FwbModalExamplePersistent.vue'
+import FwbModalExamplePosition from './modal/examples/FwbModalExamplePosition.vue'
 </script>
 # Vue Modal - Flowbite
 
@@ -84,6 +85,33 @@ The default value is: `2xl`
   <fwb-modal size="md" />
   <fwb-modal size="xl" />
   <fwb-modal size="5xl" />
+</template>
+
+<script setup>
+import { FwbModal } from 'flowbite-vue'
+</script>
+```
+
+## Position
+
+The `position` prop allows you to control the placement of the modal on the screen. You can choose from the following options:
+
+`bottom-left`, `bottom-right`, `bottom-center`, `top-left`, `top-center`, `top-right`, `center-left`, `center`, `center-right`
+
+The default value is: `center`
+
+<fwb-modal-example-position />
+```vue
+<template>
+  <fwb-modal position="bottom-left" />
+  <fwb-modal position="bottom-right" />
+  <fwb-modal position="bottom-center" />
+  <fwb-modal position="top-left" />
+  <fwb-modal position="top-center" />
+  <fwb-modal position="top-right" />
+  <fwb-modal position="center-left" />
+  <fwb-modal position="center" />
+  <fwb-modal position="center-right" />
 </template>
 
 <script setup>

--- a/docs/components/modal/examples/FwbModalExample.vue
+++ b/docs/components/modal/examples/FwbModalExample.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="vp-raw flex justify-start">
+  <div class="flex justify-start vp-raw">
     <fwb-button @click="showModal">
       {{ triggerText }}
     </fwb-button>
@@ -8,6 +8,7 @@
       :not-escapable="notEscapable"
       :persistent="persistent"
       :size="size"
+      :position="position"
       @close="closeModal"
     >
       <template #header>
@@ -45,13 +46,14 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
 import { FwbButton, FwbModal } from '../../../../src/index'
-import { type ModalSize } from '../../../../src/components/FwbModal/types'
+import { type ModalPosition, type ModalSize } from '../../../../src/components/FwbModal/types'
 
 interface ModalProps {
   size?: ModalSize,
   notEscapable?: boolean,
   persistent?: boolean,
   triggerText?: string
+  position?: ModalPosition
 }
 
 withDefaults(defineProps<ModalProps>(), {
@@ -59,6 +61,7 @@ withDefaults(defineProps<ModalProps>(), {
   notEscapable: false,
   persistent: false,
   triggerText: 'Open Modal',
+  position: 'center',
 })
 
 const isShowModal = ref(false)

--- a/docs/components/modal/examples/FwbModalExamplePosition.vue
+++ b/docs/components/modal/examples/FwbModalExamplePosition.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="flex flex-wrap justify-start gap-2 vp-raw">
+    <span>
+      <fwb-modal-example
+        position="bottom-left"
+        trigger-text="Bottom Left"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="bottom-right"
+        trigger-text="Bottom Right"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="bottom-center"
+        trigger-text="Bottom Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="top-left"
+        trigger-text="Top Left"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="top-center"
+        trigger-text="Top Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="top-right"
+        trigger-text="Top Right"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center-left"
+        trigger-text="Center Left"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center"
+        trigger-text="Center"
+      />
+    </span>
+    <span>
+      <fwb-modal-example
+        position="center-right"
+        trigger-text="Center Right"
+      />
+    </span>
+  </div>
+</template>
+
+<script setup>
+import FwbModalExample from './FwbModalExample.vue'
+</script>

--- a/src/components/FwbModal/FwbModal.vue
+++ b/src/components/FwbModal/FwbModal.vue
@@ -1,23 +1,23 @@
 <template>
   <div>
-    <div class="bg-gray-900 bg-opacity-50 dark:bg-opacity-80 fixed inset-0 z-40" />
+    <div class="fixed inset-0 z-40 bg-gray-900 bg-opacity-50 dark:bg-opacity-80" />
     <div
       ref="modalRef"
-      class="overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 w-full md:inset-0 h-modal md:h-full justify-center items-center flex"
+      class="fixed top-0 left-0 right-0 z-50 grid w-full overflow-x-hidden overflow-y-auto md:inset-0 h-modal md:h-full"
       tabindex="0"
       @click.self="clickOutside"
       @keyup.esc="closeWithEsc"
     >
       <div
-        :class="`${modalSizeClasses[size]}`"
-        class="relative p-4 w-full h-full"
+        :class="`${modalSizeClasses[size]} ${modalPositionClasses[position]}`"
+        class="relative w-full p-4"
       >
         <!-- Modal content -->
         <div class="relative bg-white rounded-lg shadow dark:bg-gray-700">
           <!-- Modal header -->
           <div
             :class="$slots.header ? 'border-b border-gray-200 dark:border-gray-600' : ''"
-            class="p-4 rounded-t flex justify-between items-center"
+            class="flex items-center justify-between p-4 rounded-t"
           >
             <slot name="header" />
             <button
@@ -51,7 +51,7 @@
           <!-- Modal footer -->
           <div
             v-if="$slots.footer"
-            class="p-6 rounded-b border-gray-200 border-t dark:border-gray-600"
+            class="p-6 border-t border-gray-200 rounded-b dark:border-gray-600"
           >
             <slot name="footer" />
           </div>
@@ -63,18 +63,20 @@
 
 <script lang="ts" setup>
 import { onMounted, ref, type Ref } from 'vue'
-import type { ModalSize } from './types'
+import type { ModalPosition, ModalSize } from './types'
 
 interface ModalProps {
   notEscapable?: boolean,
   persistent?: boolean
   size?: ModalSize,
+  position?: ModalPosition
 }
 
 const props = withDefaults(defineProps<ModalProps>(), {
   notEscapable: false,
   persistent: false,
   size: '2xl',
+  position: 'center',
 })
 
 const emit = defineEmits(['close', 'click:outside'])
@@ -90,6 +92,18 @@ const modalSizeClasses = {
   '5xl': 'max-w-5xl',
   '6xl': 'max-w-6xl',
   '7xl': 'max-w-7xl',
+}
+
+const modalPositionClasses = {
+  'bottom-left': 'self-end justify-self-start',
+  'bottom-right': 'self-end justify-self-end',
+  'bottom-center': 'self-end justify-self-center',
+  'top-left': 'self-start justify-self-start',
+  'top-right': 'self-start justify-self-end',
+  'top-center': 'self-start justify-self-center',
+  'center-left': 'self-center justify-self-start',
+  center: 'self-center justify-self-center',
+  'center-right': 'self-center justify-self-end',
 }
 
 function closeModal () {


### PR DESCRIPTION
As can be seen on Modal page position example now we can control modal's position. Also this PR fixes a bug of incorrect click outside behaviour - click underneath the modal didn't trigger the close action. By default modal will be placed to the center of the screen.